### PR TITLE
Revamp study resources and header navigation

### DIFF
--- a/src/components/header/Header.jsx
+++ b/src/components/header/Header.jsx
@@ -57,15 +57,18 @@ const Header = () => {
                     alt="logo"
                   />
                 </Link>
-                <p className="logo-text">SAMARTH</p>
+                <Link to="/" className="logo-text" style={{ textDecoration: 'none' }}>
+                  SAMARTH
+                </Link>
               </div>
 
               <div className="header__right">
                 <nav
                   id="main-nav"
                   className={`main-nav ${menuActive ? "active" : ""}`}
+                  style={{ display: 'flex', justifyContent: 'center' }}
                 >
-                  <ul id="menu-primary-menu" className="menu">
+                  <ul id="menu-primary-menu" className="menu" style={{ display: 'flex', gap: '2.5rem', alignItems: 'center', justifyContent: 'center', padding: 0, margin: 0 }}>
                     {menus.map((data, idx) => (
                       <li
                         key={idx}

--- a/src/pages/Study.jsx
+++ b/src/pages/Study.jsx
@@ -1,5 +1,7 @@
+
 import React, { useState, useEffect } from "react";
 import "../scss/component/_aspirants.scss";
+import "./resc.css";
 
 import PageTitle from "../components/pagetitle/PageTitle";
 import UpcomingExams from "../components/aspirants/UpcomingExams";
@@ -11,42 +13,115 @@ import study_channel from "../assets/fake-data/dataStudy/study_channel";
 import Websites from "../components/aspirants/Websites";
 import {notes,pyqs} from "../assets/fake-data/dataStudy/notes";
 
+// Exam.jsx imports
+import dataGate from '../assets/fake-data/data-gate';
+import dataGate2 from '../assets/fake-data/data-gate-02';
+import dataSSC from '../assets/fake-data/data-ssc';
+import dataSSC2 from '../assets/fake-data/data-ssc-02';
+import Gate from '../components/resources/gate';
+import Cat from '../components/resources/cat';
+import UPSC_CSE from '../components/resources/upsc-cse';
+import dataCat from '../assets/fake-data/data-cat';
+import UPSC_ESE from '../components/resources/upsc-ese';
+import SSC_CGL from '../components/resources/ssc';
+
+// Aspirants.jsx imports
+import upcomingExams_data from "../assets/fake-data/dataForAspirants/upcoming-exams_data";
+import videos_data from "../assets/fake-data/dataForAspirants/videos_data";
+import channel_data from "../assets/fake-data/dataForAspirants/channel_data";
+import websites_data from "../assets/fake-data/dataForAspirants/websites_data";
+
+
+
 function Study() {
+  const [selectedContent, setSelectedContent] = useState('content-1');
+
+  const handleNavItemClick = (contentId) => {
+    setSelectedContent(contentId);
+  };
+
   return (
-    <div className="wrapper">
-      <PageTitle title="Study Material" desc="All Resources you Need" />
+    <div className="wrapper unified-study-page">
+      <PageTitle title="Study & Exam Resources" desc="Everything you need for your preparation journey" />
+
+      {/* Notices Section */}
       <div className="block-text center flexcenter">
-        <h3 className="heading">Notices</h3>
+        <h3 className="heading">Latest Notices</h3>
         <div className="topic">
-          <UpcomingExams data={notices}></UpcomingExams>
+          <UpcomingExams data={notices} />
         </div>
       </div>
 
-      {/* <div className="block-text center">
-        <h3 className="heading">Study Playlists</h3>
-        <div className="topic">
-          <Videos data={playlists}></Videos>
+      {/* Unified Resources Section */}
+      <div className="unified-resources">
+        <div className="block-text center">
+          <h3 className="heading">Exam Resources</h3>
+          <div className="exam-tabs">
+            <ul className="breacrumb1" style={{ display: 'flex', flexDirection: 'row', gap: '2rem', justifyContent: 'center', padding: 0, margin: '1rem 0' }}>
+              <li className={`nav-itemexam ${selectedContent === 'content-1' ? 'active' : ''}`} style={{ listStyle: 'none', cursor: 'pointer', padding: '0.5rem 1rem', borderRadius: '6px' }} onClick={() => handleNavItemClick('content-1')}>GATE</li>
+              <li className={`nav-itemexam ${selectedContent === 'content-2' ? 'active' : ''}`} style={{ listStyle: 'none', cursor: 'pointer', padding: '0.5rem 1rem', borderRadius: '6px' }} onClick={() => handleNavItemClick('content-2')}>CAT</li>
+              <li className={`nav-itemexam ${selectedContent === 'content-3' ? 'active' : ''}`} style={{ listStyle: 'none', cursor: 'pointer', padding: '0.5rem 1rem', borderRadius: '6px' }} onClick={() => handleNavItemClick('content-3')}>UPSC-CSE</li>
+              <li className={`nav-itemexam ${selectedContent === 'content-4' ? 'active' : ''}`} style={{ listStyle: 'none', cursor: 'pointer', padding: '0.5rem 1rem', borderRadius: '6px' }} onClick={() => handleNavItemClick('content-4')}>UPSC-ESE</li>
+              <li className={`nav-itemexam ${selectedContent === 'content-5' ? 'active' : ''}`} style={{ listStyle: 'none', cursor: 'pointer', padding: '0.5rem 1rem', borderRadius: '6px' }} onClick={() => handleNavItemClick('content-5')}>SSC-CGL</li>
+            </ul>
+            <div className="contentexam">
+              {selectedContent === 'content-1' && <Gate data={dataGate} data2={dataGate2} />}
+              {selectedContent === 'content-2' && <Cat data={dataCat} />}
+              {selectedContent === 'content-3' && <UPSC_CSE />}
+              {selectedContent === 'content-4' && <UPSC_ESE />}
+              {selectedContent === 'content-5' && <SSC_CGL data={dataSSC} data2={dataSSC2} />}
+            </div>
+          </div>
         </div>
-      </div> */}
 
-      <div className="block-text center">
-        <h3 className="heading">Channels To Follow</h3>
-        <div className="topic">
-          <Channels data={study_channel}></Channels>
+        <div className="block-text center">
+          <h3 className="heading">Study Materials</h3>
+          <div className="topic">
+            <div className="study-materials-grid" style={{ display: 'flex', gap: '2rem', flexWrap: 'wrap', justifyContent: 'center' }}>
+              <div style={{ minWidth: 220, marginBottom: '1.5rem' }}>
+                <h4 style={{ marginBottom: '1rem' }}>Organizer</h4>
+                <div style={{ padding: '0.5rem 0 0.5rem 0', minHeight: '60px' }}>
+                  <Websites data={notes} />
+                </div>
+              </div>
+              <div style={{ minWidth: 220, marginBottom: '1.5rem' }}>
+                <h4 style={{ marginBottom: '1rem' }}>PYQs</h4>
+                <div style={{ padding: '0.5rem 0 0.5rem 0', minHeight: '60px' }}>
+                  <Websites data={pyqs} />
+                </div>
+              </div>
+              <div style={{ minWidth: 220, marginBottom: '1.5rem' }}>
+                <h4 style={{ marginBottom: '1rem' }}>Playlists</h4>
+                <div style={{ padding: '0.5rem 0 0.5rem 0', minHeight: '60px' }}>
+                  <Videos data={playlists} />
+                </div>
+              </div>
+              <div style={{ minWidth: 220, marginBottom: '1.5rem' }}>
+                <h4>Channels</h4>
+                <Channels data={study_channel} />
+              </div>
+            </div>
+          </div>
         </div>
-      </div>
 
-      <div className="block-text center">
-        <h3 className="heading">MAKAUT Organizer</h3>
-        <div className="topic">
-          <Websites data={notes}></Websites>
-        </div>
-      </div>
-
-      <div className="block-text center">
-        <h3 className="heading">MAKAUT PYQs</h3>
-        <div className="topic">
-          <Websites data={pyqs}></Websites>
+        <div className="block-text center">
+          <h3 className="heading">Aspirant Resources</h3>
+          <div className="topic aspirant-resources-grid" style={{ display: 'flex', gap: '2rem', flexWrap: 'wrap', justifyContent: 'center' }}>
+            <div style={{ minWidth: 220, marginBottom: '1.5rem' }}>
+              <h4>Video Resources</h4>
+              <Videos data={videos_data} />
+            </div>
+            <div style={{ minWidth: 220, marginBottom: '1.5rem' }}>
+              <h4>Channels</h4>
+              <Channels data={channel_data} />
+            </div>
+            <div style={{ minWidth: 220, marginBottom: '1.5rem' }}>
+              <h4 style={{ marginBottom: '1rem' }}>Websites</h4>
+              <div style={{ padding: '0.5rem 0 0.5rem 0', minHeight: '60px' }}>
+                <Websites data={websites_data} />
+              </div>
+            </div>
+          </div>
         </div>
       </div>
 

--- a/src/pages/menu.jsx
+++ b/src/pages/menu.jsx
@@ -12,12 +12,12 @@ const menus = [
         // isNew: 'true',
     },
     
-    {
-        id: 9,
-        name: ' ',
-        links: '#',
-        className: 'menu-spacing', // Added spacing between Study Material and Wings
-    },
+    // {
+    //     id: 9,
+    //     name: ' ',
+    //     links: '#',
+    //     className: 'menu-spacing', // Added spacing between Study Material and Wings
+    // },
 
     {
         id: 2,
@@ -46,17 +46,7 @@ const menus = [
                 sub: 'Gallery',
                 links: '/gallery'
             },
-            {
-                id: 4,
-                sub: 'Resources',
-                links: '/Resources'
-            },
-            {
-                id: 5,
-                sub: 'For Aspirants',
-                links: '/Aspirants',
-                // isNew: true // Added property to indicate whether to show "NEW" blinker
-            },
+            
         ]
 
     },


### PR DESCRIPTION
Unified the Study page to combine exam resources, study materials, and aspirant resources into a single, organized layout with tabbed navigation for exams. Improved header navigation styling and replaced the logo text with a link. Cleaned up the menu configuration by commenting out unused spacing and removing redundant resource links.